### PR TITLE
Update .gitignore and README.md for improved clarity and structure

### DIFF
--- a/.copilot.md
+++ b/.copilot.md
@@ -1,30 +1,77 @@
 # Copilot Project Instructions – Enigma Machine
 
-## Architecture Rules
-- Maintain strict separation between `machine`, `engine`, `loader`, and `ui`.
-- No UI logic inside engine or machine.
-- Machine contains rotor, reflector, and plugboard mechanics.
-- Engine manages machine state, code setup, validation, and history.
-- Loader handles XML parsing and validation only.
+These instructions guide Copilot to generate **correct, assignment-compliant** code.
 
-## Code Style
-- Java 21
-- Meaningful class and method names
-- No static utility blobs unless necessary
-- Prefer interfaces for abstractions that evolve across exercises
-- Immutable models where possible (Alphabet, Mapping, Code configuration)
+## Architecture Requirements
+- Use modules: `machine` (core logic), `engine` (operations, validation, history), `loader` (XML parsing), `console` (UI only).
+- Exercise 3: add Spring Boot controllers + services.
+- No printing or UI logic in machine/engine/loader.
+- Engine is passive: does not know the caller.
+- Exchange data only through DTOs.
+- Do not expose internal machine objects (rotors, reflectors, plugboard).
 
-## Exercise Compatibility
-- Exercise 1: Console + single project
-- Exercise 2: Multi-module Maven; same package structure must remain stable
-- Exercise 3: Spring Boot server; engine code must be service-ready (stateless or clearly stateful)
+## Code Style (Java Code Conventions)
+- Java 21.
+- Naming:
+    - Classes: UpperCamelCase
+    - Methods/vars: lowerCamelCase
+    - Constants: UPPER_SNAKE_CASE
+- Keep indentation consistent; avoid long methods and code duplication.
+- Prefer immutable models (Alphabet, Mapping, CodeConfiguration).
+- Keep class responsibilities narrow; avoid “god objects”.
+- Avoid unnecessary static utilities.
+- Follow clean imports (remove unused ones).
+
+## XML Loader Rules
+- XML is schema-valid but may be application-invalid—must validate:
+    - even alphabet length,
+    - rotor IDs consecutive 1..N,
+    - reflectors with unique Roman IDs,
+    - reflector cannot map a letter to itself,
+    - Rotor mapping must be bijective (no duplicates in left/right columns).
+- Invalid XML → return clear error without overriding previous machine.
+- Valid XML → fully override machine and reset history.
+
+## Code Configuration Rules
+- Rotor order is right → left.
+- Initial position uses the **right** mapping column.
+- Manual configuration:
+    - rotor ID list (comma-separated),
+    - rotor initial positions (string of characters),
+    - reflector Roman numeral,
+    - (Ex2) plug pairs: even-length string, no repetitions, no self-mapping.
+- Automatic configuration: random valid code, returned in compact format.
+
+## Machine Behavior
+- Rotors step: rightmost always steps; propagation occurs when notch is at window.
+- Processing updates rotor positions (no auto-reset).
+- Reset restores original (initial) code configuration.
+- Reject characters not in alphabet.
+
+## History & Statistics
+- Track: original code, all used codes, all messages, durations (nano), grouped by code.
+- Reset history only when a **valid new XML** is loaded.
+
+## Maven (Exercise 2)
+- Multi-module Maven with aggregator POM.
+- Use assembly plugin to create uber-jar.
+- Final artifact name: `enigma-machine-ex2.jar`.
+
+## Spring Boot (Exercise 3)
+- Root endpoint: `/enigma`.
+- Controllers provide routing only; services contain logic.
+- JSON structures must match required format exactly.
+- Produce Spring Boot uber-jar: `enigma-machine-server-ex3.jar`.
+
+## Console/UI Rules
+- UI prints only and reads from Scanner.
+- All numbering for user interaction starts at 1.
+- Errors must be clear, readable, and actionable.
+- No colors, no clearing console, no fancy output.
 
 ## Do Not Generate
-- No package-private classes unless intentional
-- No business logic inside console UI
-- No direct printing from machine or engine
-
-## Additional Notes
-- Prepare for plugboard support (Exercise 2)
-- Prepare for REST mapping (Exercise 3)
-- Avoid hardcoding XML names or paths
+- No business logic in UI.
+- No printing inside machine, engine, or loader.
+- No exposure of internal state objects.
+- No hardcoding XML paths.
+- No Hebrew in output.


### PR DESCRIPTION
This pull request revises the `.copilot.md` instructions to clarify and expand the architectural, code style, and validation requirements for the Enigma Machine project. The changes emphasize strict module boundaries, introduce more detailed validation rules, and add requirements for future exercises, including Spring Boot and Maven integration.

Architecture and module boundaries:

* Updated module definitions to include `console` for UI, clarified separation between logic, validation, and UI, and specified that engine is passive and communicates only via DTOs. Internal machine objects are not exposed.

Validation and configuration rules:

* Added comprehensive XML loader validation requirements (alphabet length, rotor IDs, reflector uniqueness, mapping bijectivity), error handling for invalid XML, and rules for code configuration (rotor order, initial positions, plug pairs, and random code generation).

Code style and conventions:

* Expanded code style guidelines with naming conventions, immutability, clean imports, and avoidance of “god objects” and unnecessary static utilities.

Exercise-specific requirements:

* Included Maven multi-module setup and assembly plugin usage for Exercise 2, and Spring Boot controller/service separation, endpoint specification, and JSON format requirements for Exercise 3.

UI and error handling:

* Clarified UI responsibilities (printing only, numbering from