### PR TITLE
feat(Engine, Machine): implement reset functionality and add machine …

### DIFF
--- a/enigma-engine/src/enigma/engine/Engine.java
+++ b/enigma-engine/src/enigma/engine/Engine.java
@@ -78,13 +78,7 @@ public interface Engine {
 
     void reset();
 
-    /**
-     * Return or print runtime statistics (usage, timing, or other metrics).
-     *
-     * <p>Exact format and destination are implementation-specific.
-     * Currently a placeholder for future implementation.</p>
-     */
-    void statistics();
+    String history();
 
     void terminate();
 

--- a/enigma-engine/src/enigma/engine/EngineValidator.java
+++ b/enigma-engine/src/enigma/engine/EngineValidator.java
@@ -233,10 +233,43 @@ public final class EngineValidator {
      * Truncate a string for display with ellipsis if too long.
      */
     private static String truncateForDisplay(String str, int maxLen) {
-        if (str.length() <= maxLen) {
-            return str;
+        if (str == null) {
+            return null;
         }
-        return str.substring(0, maxLen) + "...";
+
+        // First, escape control/non-printable characters to visible markers (e.g., \n, \t, ESC)
+        String escaped = escapeControlChars(str);
+
+        if (escaped.length() <= maxLen) {
+            return escaped;
+        }
+        return escaped.substring(0, maxLen) + "...";
+    }
+
+    /**
+     * Replace ISO control and other non-printable characters with visible escape sequences.
+     * Examples: newline -> "\\n", tab -> "\\t", ESC -> "\\u001B", other controls -> "\\uXXXX".
+     */
+    private static String escapeControlChars(String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch ((int) c) {
+                case 0 -> sb.append("\\0");
+                case 9 -> sb.append("\\t");
+                case 10 -> sb.append("\\n");
+                case 13 -> sb.append("\\r");
+                case 27 -> sb.append("\\u001B");
+                default -> {
+                    if (Character.isISOControl(c)) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
     }
 
     /**

--- a/enigma-engine/src/enigma/engine/history/MachineHistory.java
+++ b/enigma-engine/src/enigma/engine/history/MachineHistory.java
@@ -1,0 +1,70 @@
+package enigma.engine.history;
+
+import enigma.shared.dto.record.MessageRecord;
+import enigma.shared.state.CodeState;
+import java.util.*;
+
+public final class MachineHistory {
+
+    // Original code -> all message runs under that code
+    private final Map<CodeState, List<MessageRecord>> history = new LinkedHashMap<>();
+
+    // The original code currently in effect
+    private CodeState currentOriginalCode;
+
+    public void recordConfig(CodeState codeState) {
+        if (codeState == null) {
+            throw new IllegalArgumentException(
+                    "Cannot record configuration: codeState is null.");
+        }
+
+        // Set the currently active original code state
+        currentOriginalCode = codeState;
+
+        // Ensure this codeState has an entry in the history map
+        history.computeIfAbsent(codeState, k -> new ArrayList<>());
+    }
+
+    public void recordMessage(String input, String output, long durationNanos) {
+        if (currentOriginalCode == null) {
+            throw new IllegalStateException(
+                    "Cannot record message: No original code has been configured yet.");
+        }
+
+        // Defensive — should never happen if recordConfig() is correct
+        List<MessageRecord> messages = history.computeIfAbsent(currentOriginalCode, k -> new ArrayList<>());
+
+        messages.add(new MessageRecord(input, output, durationNanos));
+    }
+
+    @Override
+    public String toString() {
+        if (history.isEmpty()) {
+            return "No history available. No messages were processed.";
+        }
+
+        StringBuilder sb = new StringBuilder();
+
+        for (Map.Entry<CodeState, List<MessageRecord>> entry : history.entrySet()) {
+            CodeState code = entry.getKey();
+            List<MessageRecord> records = entry.getValue();
+
+            sb.append("=== Original Code: ")
+                    .append(code)
+                    .append(" ===\n");
+
+            if (records.isEmpty()) {
+                sb.append("  No messages processed under this configuration.\n\n");
+                continue;
+            }
+
+            for (MessageRecord record : records) {
+                sb.append("  • ").append(record.toString()).append("\n");
+            }
+
+            sb.append("\n");
+        }
+
+        return sb.toString();
+    }
+}

--- a/enigma-machine/src/enigma/machine/Machine.java
+++ b/enigma-machine/src/enigma/machine/Machine.java
@@ -43,4 +43,6 @@ public interface Machine {
     CodeConfig getConfig();
 
     CodeState getCodeState();
+
+    void reset();
 }

--- a/enigma-machine/src/enigma/machine/MachineImpl.java
+++ b/enigma-machine/src/enigma/machine/MachineImpl.java
@@ -117,7 +117,7 @@ public class MachineImpl implements Machine {
         // Forward pass (right→left)
         List<RotorTrace> forwardSteps = forwardTransform(intermediate);
         if (!forwardSteps.isEmpty()) {
-            intermediate = forwardSteps.get(forwardSteps.size() - 1).exitIndex();
+            intermediate = forwardSteps.getLast().exitIndex();
         }
 
         // Reflector
@@ -132,7 +132,7 @@ public class MachineImpl implements Machine {
         // Backward pass (left→right)
         List<RotorTrace> backwardSteps = backwardTransform(intermediate);
         if (!backwardSteps.isEmpty()) {
-            intermediate = backwardSteps.get(backwardSteps.size() - 1).exitIndex();
+            intermediate = backwardSteps.getLast().exitIndex();
         }
 
         char outputChar = keyboard.toChar(intermediate);
@@ -175,6 +175,12 @@ public class MachineImpl implements Machine {
     @Override
     public CodeConfig getConfig() {
         return code.getConfig();
+    }
+
+    @Override
+    public void reset() {
+        ensureConfigured();
+        code.reset();
     }
 
     // ---------------------------------------------------------

--- a/enigma-machine/src/enigma/machine/component/code/Code.java
+++ b/enigma-machine/src/enigma/machine/component/code/Code.java
@@ -72,4 +72,6 @@ public interface Code {
     CodeConfig getConfig();
 
     List<Integer> getNotchDist();
+
+    void reset();
 }

--- a/enigma-machine/src/enigma/machine/component/code/CodeImpl.java
+++ b/enigma-machine/src/enigma/machine/component/code/CodeImpl.java
@@ -94,4 +94,14 @@ public class CodeImpl implements Code {
         }
         return notchDist;
     }
+
+    @Override
+    public void reset() {
+        for (int i = 0; i < rotors.size(); i++) {
+            Rotor r = rotors.get(i);
+            char pos = positions.get(i);
+            r.setPosition(pos);
+        }
+
+    }
 }

--- a/enigma-shared/src/enigma/shared/dto/record/MessageRecord.java
+++ b/enigma-shared/src/enigma/shared/dto/record/MessageRecord.java
@@ -1,0 +1,14 @@
+package enigma.shared.dto.record;
+
+public record MessageRecord(
+        String originalText,
+        String processedText,
+        long durationNanos
+) {
+    @Override
+    public String toString() {
+        return "Input=\"" + originalText + "\"" +
+                ", Output=\"" + processedText + "\"" +
+                ", Duration=" + durationNanos + "ns";
+    }
+}


### PR DESCRIPTION
This pull request introduces a machine history feature for tracking configurations and processed messages, and improves the reset functionality for the Enigma engine. It also adds utility for escaping control characters in string displays and includes some codebase cleanups and interface updates.

**Machine history and statistics:**
- Added a new `MachineHistory` class to record each code configuration and all processed messages under that configuration, including their input, output, and processing duration. The engine now exposes a `history()` method (replacing the old `statistics()` placeholder) to provide a human-readable summary of this history. (`enigma-engine/src/enigma/engine/history/MachineHistory.java` [[1]](diffhunk://#diff-f759cb19c519810e28a87f6a5e3604bc00cf6af2219d9e8b12656f1b1fbdd85eR1-R70) `enigma-shared/src/enigma/shared/dto/record/MessageRecord.java` [[2]](diffhunk://#diff-a75f294b61b919cead0106b6ad0f043a3af7b1c0bcd1073c508009c2ae143b83R1-R14) `enigma-engine/src/enigma/engine/Engine.java` [[3]](diffhunk://#diff-32363785b0ade8f0cedf79345b686eb4ff9ca0c000235df057f322307c784950L81-R81) `enigma-engine/src/enigma/engine/EngineImpl.java` [[4]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR36) [[5]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR53) [[6]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dL76-R83) [[7]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR127-R136) [[8]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR196-R246)

**Reset and configuration improvements:**
- Implemented the `reset()` method for the engine and underlying machine, ensuring rotors are reset to their original positions and proper validation is performed before resetting. (`enigma-engine/src/enigma/engine/EngineImpl.java` [[1]](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR196-R246) `enigma-machine/src/enigma/machine/Machine.java` [[2]](diffhunk://#diff-03c85c65f3b65829e552c837ce4f27c3a3b63880eb9b24fa84159fda95dd3760R46-R47) `enigma-machine/src/enigma/machine/MachineImpl.java` [[3]](diffhunk://#diff-f1fc20cbe0f29e59fee44af52456be8dd0614ed96ee6bba4608c76e3a33c7ab2R180-R185) `enigma-machine/src/enigma/machine/component/code/Code.java` [[4]](diffhunk://#diff-9737581a5e60fc21e6f6916d36c5350b368ba7e78ebced9f1b18d313945e41ddR75-R76) `enigma-machine/src/enigma/machine/component/code/CodeImpl.java` [[5]](diffhunk://#diff-7f4dbe990d084a9b06b0cb20dde5132b98b9541537bcd1f099bf333696c19fceR97-R106)

**String display and validation utilities:**
- Improved the string truncation utility to safely handle `null` input and to escape control/non-printable characters, making debug and error messages more readable. (`enigma-engine/src/enigma/engine/EngineValidator.java` [enigma-engine/src/enigma/engine/EngineValidator.javaL236-R272](diffhunk://#diff-dc2d1de68812063ff6137f5f432ffc686e077dde21e023cb9d400c3540bce623L236-R272))

**Minor codebase cleanups:**
- Replaced manual list element access with the more idiomatic `getLast()` method for clarity. (`enigma-machine/src/enigma/machine/MachineImpl.java` [[1]](diffhunk://#diff-f1fc20cbe0f29e59fee44af52456be8dd0614ed96ee6bba4608c76e3a33c7ab2L120-R120) [[2]](diffhunk://#diff-f1fc20cbe0f29e59fee44af52456be8dd0614ed96ee6bba4608c76e3a33c7ab2L135-R135)
- Marked some engine methods as deprecated to clarify their intended replacement or removal. (`enigma-engine/src/enigma/engine/EngineImpl.java` [enigma-engine/src/enigma/engine/EngineImpl.javaR255](diffhunk://#diff-18cc37ac2cca40c0e5c6ce99284f65cfa41b95b97115bf3c9d9ba2e5a57cd83dR255))…history tracking