### PR TITLE
Improve message output in MachineHistory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,7 +132,7 @@ Example (required style):
             enigma.reset();
             System.out.println("Code has been reset to original configuration");
         }
-        catch(EngineException e) {
+        catch (EngineException e) {
             System.out.println("Failed to reset code : " + e.getMessage());
         }
 ```

--- a/enigma-engine/src/enigma/engine/history/MachineHistory.java
+++ b/enigma-engine/src/enigma/engine/history/MachineHistory.java
@@ -199,15 +199,17 @@ public final class MachineHistory {
             CodeState code = entry.getKey();
             List<MessageRecord> records = entry.getValue();
 
-            if (records.isEmpty()) {
-                // Instructions: only show codes that actually processed messages
-                continue;
-            }
-
             printedAny = true;
 
             // Print the original code (instruction §7: "present the code used")
             sb.append(code).append(System.lineSeparator());
+
+            // If no strings were processed, print a message
+            if (records.isEmpty()) {
+               sb.append("  ")
+                       .append("No messages processed")
+                       .append(System.lineSeparator());
+            }
 
             // Print each record with numbering starting at 1
             for (int i = 0; i < records.size(); i++) {
@@ -219,7 +221,6 @@ public final class MachineHistory {
                         .append(r.toString())   // uses our new format
                         .append(System.lineSeparator());
             }
-
             sb.append(System.lineSeparator());
         }
         if (!printedAny) {


### PR DESCRIPTION
This pull request updates the `toString()` method in the `MachineHistory` class to improve how it displays machine history when no messages were processed for a given code. Now, instead of skipping codes with no messages, the output will explicitly state that no messages were processed for those codes, making the history output more informative and user-friendly.

Output improvements:

* The `toString()` method in `MachineHistory.java` now includes codes that did not process any messages, displaying "No messages processed" under those codes instead of omitting them from the output.

Code readability:

* Minor formatting changes were made to improve the clarity and spacing of the output.